### PR TITLE
fix(episode info): add season and episode index in 'Item' page with 3…

### DIFF
--- a/src/components/Item/MediaInfo.vue
+++ b/src/components/Item/MediaInfo.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="text--secondary">
+    <span v-if="item.Type === 'Episode'">
+      {{ item.SeasonName }} &#8226; {{ item.IndexNumber }}
+    </span>
     <span v-if="item.ProductionYear && year">{{ item.ProductionYear }}</span>
     <span v-if="item.OfficialRating && rating">{{ item.OfficialRating }}</span>
     <span v-if="item.CommunityRating && rating">


### PR DESCRIPTION
… line of html (For 'Episode')

I check the type of the item and if it is an episode, I show the information: {SeasonName,
IndexNumber} just before the year (in the line below t