### PR TITLE
feat(collections page): collection detail with tabs divided by conten…

### DIFF
--- a/src/mixins/itemHelper.ts
+++ b/src/mixins/itemHelper.ts
@@ -142,6 +142,10 @@ const itemHelper = Vue.extend({
             routeName = 'series-itemId';
             routeParams = { itemId: item.Id };
             break;
+          case 'BoxSet':
+            routeName = 'collections-itemId';
+            routeParams = { itemId: item.Id };
+            break;
           case 'Person':
             routeName = 'person-itemId';
             routeParams = { itemId: item.Id };

--- a/src/pages/collections/_itemId/index.vue
+++ b/src/pages/collections/_itemId/index.vue
@@ -1,0 +1,298 @@
+<template>
+  <item-cols>
+    <template #left>
+      <v-row justify="center" justify-md="start">
+        <v-col cols="7" md="3">
+          <card :item="item" />
+        </v-col>
+        <v-col cols="12" md="9">
+          <h1
+            class="text-h4 font-weight-light"
+            :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
+          >
+            {{ item.Name }}
+          </h1>
+          <h2
+            v-if="item.OriginalTitle && item.OriginalTitle !== item.Name"
+            class="text-subtitle-1"
+            :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
+          >
+            {{ item.OriginalTitle }}
+          </h2>
+          <div
+            class="text-caption text-h4 font-weight-medium mt-2"
+            :class="{ 'text-center': !$vuetify.breakpoint.mdAndUp }"
+          >
+            <media-info :item="item" year runtime rating ends-at />
+          </div>
+          <v-row
+            class="my-4 align-center"
+            :class="{
+              'justify-center': !$vuetify.breakpoint.mdAndUp,
+              'ml-0': $vuetify.breakpoint.mdAndUp
+            }"
+          >
+            <play-button class="mr-2" :item="item" />
+            <like-button :item="item" class="mr-2" />
+            <mark-played-button :item="item" class="mr-2" />
+            <item-menu :item="item" />
+          </v-row>
+          <v-col cols="12" md="10">
+            <v-row
+              v-if="item && item.GenreItems && item.GenreItems.length > 0"
+              align="center"
+            >
+              <v-col :cols="12" :sm="2" class="px-0 text-truncate">
+                <label class="text--secondary">{{ $t('genres') }}</label>
+              </v-col>
+              <v-col class="px-0" :cols="12" :sm="10">
+                <v-slide-group>
+                  <v-slide-item
+                    v-for="(genre, index) in item.GenreItems"
+                    :key="`genre-${genre.Id}`"
+                  >
+                    <v-chip
+                      small
+                      link
+                      :class="{ 'ml-2': index > 0 }"
+                      nuxt
+                      :to="`/genre/${genre.Id}?type=${item.Type}`"
+                    >
+                      {{ genre.Name }}
+                    </v-chip>
+                  </v-slide-item>
+                </v-slide-group>
+              </v-col>
+            </v-row>
+            <v-row
+              v-if="
+                item && directors.length > 0 && !$vuetify.breakpoint.smAndUp
+              "
+              align="center"
+            >
+              <v-col
+                :cols="12"
+                :sm="2"
+                class="mt-sm-3 py-sm-0 px-0 text-truncate"
+              >
+                <label class="text--secondary">{{ $t('directing') }}</label>
+              </v-col>
+              <v-col :cols="12" :sm="10">
+                <v-row dense>
+                  <v-col
+                    v-for="director in directors"
+                    :key="director.Id"
+                    cols="auto"
+                  >
+                    <v-chip
+                      small
+                      link
+                      nuxt
+                      :to="getItemDetailsLink(director, 'Person')"
+                    >
+                      {{ director.Name }}
+                    </v-chip>
+                  </v-col>
+                </v-row>
+              </v-col>
+            </v-row>
+            <v-row
+              v-if="item && writers.length > 0 && !$vuetify.breakpoint.smAndUp"
+              align="center"
+            >
+              <v-col
+                :cols="12"
+                :sm="2"
+                class="mt-sm-3 py-sm-0 px-0 text-truncate"
+              >
+                <label class="text--secondary">{{ $t('writing') }}</label>
+              </v-col>
+              <v-col :cols="12" :sm="10">
+                <v-row dense>
+                  <v-col v-for="writer in writers" :key="writer.Id" cols="auto">
+                    <v-chip
+                      small
+                      link
+                      nuxt
+                      :to="getItemDetailsLink(writer, 'Person')"
+                    >
+                      {{ writer.Name }}
+                    </v-chip>
+                  </v-col>
+                </v-row>
+              </v-col>
+            </v-row>
+          </v-col>
+          <div>
+            <p
+              v-if="item.Taglines && item.Taglines.length > 0"
+              class="text-subtitle-1 text-truncate"
+            >
+              {{ item.Taglines[0] }}
+            </p>
+            <p class="item-overview">{{ item.Overview }}</p>
+          </div>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col v-if="!!children" cols="12">
+          <div>
+            <v-tabs
+              v-model="currentTab"
+              class="mb-3"
+              background-color="transparent"
+            >
+              <v-tab v-for="typeList in children" :key="typeList.Type">
+                {{ typeList.Type }} ({{ typeList.Items.length }})
+              </v-tab>
+            </v-tabs>
+            <v-tabs-items v-model="currentTab" class="transparent">
+              <v-tab-item v-for="typeList in children" :key="typeList.Type">
+                <v-container>
+                  <skeleton-item-grid v-if="loading" :view-type="viewType" />
+                  <item-grid :loading="loading" :items="typeList.Items" />
+                </v-container>
+              </v-tab-item>
+            </v-tabs-items>
+          </div>
+        </v-col>
+      </v-row>
+    </template>
+    <template #right>
+      <div v-if="crew.length > 0">
+        <h2 class="text-h6 text-sm-h5">{{ $t('item.crew') }}</h2>
+        <person-list :items="crew" />
+      </div>
+      <div v-if="actors.length > 0">
+        <h2 class="text-h6 text-sm-h5">{{ $t('item.cast') }}</h2>
+        <person-list :items="actors" />
+      </div>
+      <related-items :item="item" vertical />
+    </template>
+  </item-cols>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { mapActions, mapGetters, mapState } from 'vuex';
+import { BaseItemDto, BaseItemPerson, ImageType } from '@jellyfin/client-axios';
+import { Context } from '@nuxt/types';
+import imageHelper from '~/mixins/imageHelper';
+import formsHelper from '~/mixins/formsHelper';
+import itemHelper from '~/mixins/itemHelper';
+import { isValidMD5 } from '~/utils/items';
+
+export default Vue.extend({
+  mixins: [imageHelper, formsHelper, itemHelper],
+  validate(ctx: Context) {
+    return isValidMD5(ctx.route.params.itemId);
+  },
+  async asyncData({ params, $userLibrary, store }) {
+    const itemId = params.itemId;
+
+    if (!store.getters['items/getItem'](itemId)) {
+      await $userLibrary.getItem(itemId);
+    }
+
+    return { itemId };
+  },
+  data() {
+    return {
+      itemId: '' as string,
+      parentItem: {} as BaseItemDto,
+      currentTab: 0,
+      loading: true,
+      viewType: '',
+      backdropImageSource: '',
+      currentVideoTrack: undefined as number | undefined,
+      currentAudioTrack: undefined as number | undefined,
+      currentSubtitleTrack: undefined as number | undefined
+    };
+  },
+  async fetch() {
+    this.loading = true;
+    await this.getCollectionChildren({ itemId: this.item.Id }).finally(
+      () => (this.loading = false)
+    );
+  },
+  head() {
+    return {
+      title: this.title
+    };
+  },
+  computed: {
+    ...mapGetters('items', ['getItem']),
+    ...mapGetters('collections', ['getChildren']),
+    ...mapState('page', ['title']),
+    item(): BaseItemDto {
+      return this.getItem(this.itemId);
+    },
+    children(): BaseItemDto[] {
+      return this.getChildren(this.item.Id);
+    },
+    crew(): BaseItemPerson[] {
+      let crew: BaseItemPerson[] = [];
+
+      if (this.item.People) {
+        crew = this.item.People.filter((person: BaseItemPerson) => {
+          return ['Director', 'Writer'].includes(person.Type || '');
+        });
+      }
+
+      return crew;
+    },
+    actors: {
+      get(): BaseItemPerson[] {
+        if (this.item.People) {
+          return this.item.People.filter((person: BaseItemPerson) => {
+            return person.Type === 'Actor';
+          }).slice(0, 10);
+        } else {
+          return [];
+        }
+      }
+    },
+    directors: {
+      get(): BaseItemPerson[] {
+        return this.crew.filter(
+          (person: BaseItemPerson) => person.Type === 'Director'
+        );
+      }
+    },
+    writers: {
+      get(): BaseItemPerson[] {
+        return this.crew.filter(
+          (person: BaseItemPerson) => person.Type === 'Writer'
+        );
+      }
+    }
+  },
+  watch: {
+    item: {
+      handler(val: BaseItemDto): void {
+        this.setPageTitle({ title: val.Name });
+
+        const hash = this.getBlurhash(val, ImageType.Backdrop);
+
+        this.setBackdrop({ hash });
+      },
+      immediate: true,
+      deep: true
+    }
+  },
+  mounted() {
+    this.setAppBarOpacity({ opaqueAppBar: false });
+  },
+  destroyed() {
+    this.setAppBarOpacity({ opaqueAppBar: true });
+    this.clearBackdrop();
+  },
+  methods: {
+    ...mapActions('page', ['setPageTitle', 'setAppBarOpacity']),
+    ...mapActions('backdrop', ['setBackdrop', 'clearBackdrop']),
+    ...mapActions('collections', {
+      getCollectionChildren: 'getCollectionChildren'
+    })
+  }
+});
+</script>

--- a/src/store/collections.ts
+++ b/src/store/collections.ts
@@ -1,0 +1,116 @@
+import Vue from 'vue';
+import { ActionTree, GetterTree, MutationTree } from 'vuex';
+import { BaseItemDto, BaseItemDtoQueryResult } from '@jellyfin/client-axios';
+
+export interface CollectionItem {
+  /**
+   * children: All the items that belongs to the collection ciao
+   */
+  children: { Type: string; Items: BaseItemDto[] }[];
+}
+
+export interface CollectionsState {
+  [key: string]: CollectionItem;
+}
+
+export const defaultState = (): CollectionsState => ({});
+
+export const state = defaultState;
+
+type AddChildrenMutationPayload = {
+  children: { Type: string; Items: BaseItemDto[] }[];
+  itemId?: string;
+};
+
+export const getters: GetterTree<CollectionsState, CollectionsState> = {
+  getChildren:
+    (state) =>
+    (itemId: string): CollectionItem['children'] => {
+      return state[itemId]?.children || [];
+    }
+};
+
+export const mutations: MutationTree<CollectionsState> = {
+  ADD_COLLECTION_CHILDREN(
+    state: CollectionsState,
+    { children, itemId }: AddChildrenMutationPayload
+  ) {
+    if (!itemId) {
+      throw new Error('itemId is undefined');
+    }
+
+    Vue.set(state, itemId, {
+      children: children || {}
+    });
+  },
+  CLEAR_CHILDREN(state: CollectionsState) {
+    Object.assign(state, defaultState());
+  }
+};
+export const actions: ActionTree<CollectionsState, CollectionsState> = {
+  async getCollectionChildren({ dispatch }, { itemId }: { itemId: string }) {
+    try {
+      const { data } = await this.$api.items.getItems({
+        userId: this.$auth.user?.Id,
+        parentId: itemId
+      });
+
+      dispatch('getCollectionChildrenSuccess', {
+        response: data,
+        itemId
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      dispatch('getCollectionChildrenFailure', error);
+    }
+  },
+  getCollectionChildrenSuccess(
+    { commit },
+    {
+      response,
+      itemId
+    }: {
+      response: BaseItemDtoQueryResult;
+      itemId: string;
+    }
+  ) {
+    const children: { [key: string]: BaseItemDto[] } = {};
+
+    response.Items?.forEach((item: BaseItemDto) => {
+      if (item.Type && typeof item.Type === 'string') {
+        if (!children[item.Type]) children[item.Type] = [];
+
+        children[item.Type].push(item);
+      }
+    });
+
+    const perTypeList = Object.keys(children).map((type) => {
+      return { Type: type, Items: children[type] };
+    });
+
+    const perTypeOrderedList = perTypeList.sort(
+      (a, b) => b.Items.length - a.Items.length
+    );
+
+    commit('ADD_COLLECTION_CHILDREN', {
+      children: perTypeOrderedList,
+      itemId
+    } as AddChildrenMutationPayload);
+  },
+  getCollectionChildrenFailure: async ({ dispatch }, error) => {
+    await dispatch(
+      'snackbar/pushSnackbarMessage',
+      {
+        message: error.message,
+        color: 'error'
+      },
+      {
+        root: true
+      }
+    );
+  },
+  clearChildren({ commit }) {
+    commit('CLEAR_CHILDREN');
+  }
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,7 @@ import { playbackReportingPlugin } from './plugins/playbackReportingPlugin';
 import { preferencesSync } from './plugins/preferencesSyncPlugin';
 import { userPlugin } from './plugins/userPlugin';
 import { SocketState } from './socket';
+import { CollectionsState } from './collections';
 
 export const plugins = [
   websocketPlugin,
@@ -51,6 +52,7 @@ export interface AppState extends RootState {
   servers: ServerState;
   snackBar: SnackbarState;
   tvShows: TvShowsState;
+  collections: CollectionsState;
   user: UserState;
   userViews: UserViewsState;
   socket: SocketState;
@@ -78,6 +80,7 @@ export const actions: ActionTree<RootState, RootState> = {
     promises.push(dispatch('playbackManager/stop', { root: true }));
     promises.push(dispatch('snackbar/resetMessage', { root: true }));
     promises.push(dispatch('tvShows/clearTvShows', { root: true }));
+    promises.push(dispatch('collections/clearChildren', { root: true }));
     promises.push(dispatch('user/clearUser', { root: true }));
     promises.push(dispatch('userViews/clearUserViews', { root: true }));
     promises.push(dispatch('socket/closeSocket', { root: true }));


### PR DESCRIPTION
…t type (like series detail)

I created a new page called "collections/_itemId" starting with the "series/_itemId" page (and the
SeasonTabs component) as a starting point.   I created a store called collections where I provided
an action (getCollectionChildren) to call the "items.getItems" API by setting {userId, parentId} as
filters to get all the items belonging to the collection (and added the related functions of Success
and Fault, as well as the delete function for the reset).   In the store I set the "children"
property which consists of a list of {type, items} objects to facilitate the use of the tabs on the
page.   For better UX I have also reordered this list (divided by item type) by number of items.

#760 [Feature] Make a collections page