### PR TITLE
Play/Pause/Fullscreen shorthands

### DIFF
--- a/src/components/Players/PlayerManager.vue
+++ b/src/components/Players/PlayerManager.vue
@@ -279,6 +279,8 @@ export default Vue.extend({
   },
   mounted() {
     document.addEventListener('mousemove', this.handleMouseMove);
+    window.addEventListener('keyup', this.handleKeyPress);
+    window.addEventListener('click', this.handleVideoClick);
 
     this.addMediaHandlers();
 
@@ -286,9 +288,7 @@ export default Vue.extend({
       switch (mutation.type) {
         case 'playbackManager/TOGGLE_MINIMIZE':
           if (state.playbackManager.isMinimized === true) {
-            window.removeEventListener('keydown', this.handleKeyPress);
-          } else if (state.playbackManager.isMinimized === false) {
-            window.addEventListener('keydown', this.handleKeyPress);
+            window.removeEventListener('keyup', this.handleKeyPress);
           }
 
           break;
@@ -301,6 +301,8 @@ export default Vue.extend({
     }
 
     document.removeEventListener('mousemove', this.handleMouseMove);
+    window.removeEventListener('keyup', this.handleKeyPress);
+    window.removeEventListener('click', this.handleVideoClick);
     this.removeMediaHandlers();
     this.unsubscribe();
   },
@@ -390,6 +392,16 @@ export default Vue.extend({
             this.skipBackward();
             break;
         }
+      }
+    },
+    handleVideoClick(e: MouseEvent) {
+      const target = e.target as any;
+
+      if (
+        target?.classList?.contains('player-overlay') &&
+        this.getCurrentlyPlayingMediaType === 'Video'
+      ) {
+        this.playPause();
       }
     },
     addMediaHandlers(): void {

--- a/src/components/Players/PlayerManager.vue
+++ b/src/components/Players/PlayerManager.vue
@@ -228,7 +228,6 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 import screenfull from 'screenfull';
 import imageHelper from '~/mixins/imageHelper';
 import timeUtils from '~/mixins/timeUtils';
-import { AppState } from '~/store';
 import { PlaybackStatus } from '~/store/playbackManager';
 
 export default Vue.extend({
@@ -242,7 +241,8 @@ export default Vue.extend({
       keepOpen: false,
       playbackData: false,
       isUpNextVisible: false,
-      stretchVideo: true
+      stretchVideo: true,
+      previousVolume: 0
     };
   },
   computed: {
@@ -253,7 +253,12 @@ export default Vue.extend({
       'getCurrentlyPlayingMediaType'
     ]),
     ...mapState('clientSettings', ['darkMode']),
-    ...mapState('playbackManager', ['status', 'isMinimized', 'currentTime']),
+    ...mapState('playbackManager', [
+      'status',
+      'isMinimized',
+      'currentTime',
+      'currentVolume'
+    ]),
     isPlaying(): boolean {
       return this.status !== PlaybackStatus.Stopped;
     },
@@ -283,17 +288,6 @@ export default Vue.extend({
     window.addEventListener('click', this.handleVideoClick);
 
     this.addMediaHandlers();
-
-    this.unsubscribe = this.$store.subscribe((mutation, state: AppState) => {
-      switch (mutation.type) {
-        case 'playbackManager/TOGGLE_MINIMIZE':
-          if (state.playbackManager.isMinimized === true) {
-            window.removeEventListener('keyup', this.handleKeyPress);
-          }
-
-          break;
-      }
-    });
   },
   beforeDestroy() {
     if (this.fullScreenOverlayTimer) {
@@ -314,6 +308,7 @@ export default Vue.extend({
       'setNextTrack',
       'setPreviousTrack',
       'setLastItemIndex',
+      'setVolume',
       'playPause',
       'pause',
       'unpause',
@@ -342,6 +337,14 @@ export default Vue.extend({
           this.fullScreenOverlayTimer = null;
         }
       }, this.getOsdTimeoutDuration());
+    },
+    toggleMute(): void {
+      if (this.currentVolume !== 0) {
+        this.previousVolume = this.currentVolume;
+        this.setVolume({ volume: 0 });
+      } else {
+        this.setVolume({ volume: this.previousVolume });
+      }
     },
     handleMouseMove(): void {
       if (
@@ -380,15 +383,34 @@ export default Vue.extend({
     },
     handleKeyPress(e: KeyboardEvent): void {
       if (!this.isMinimized && this.isPlaying) {
+        const focusEl = document.activeElement;
+
+        let spaceEnabled = false;
+
+        if (e.key === 'Spacebar' || e.key === ' ') {
+          spaceEnabled =
+            focusEl?.classList.contains('v-dialog__content') ||
+            focusEl?.classList.contains('hide-pointer') ||
+            focusEl?.className === '';
+        }
+
         switch (e.key) {
           case 'Spacebar':
           case ' ':
+            if (spaceEnabled) {
+              this.playPause();
+            }
+
+            break;
+          case 'k':
             this.playPause();
             break;
           case 'ArrowRight':
+          case 'l':
             this.skipForward();
             break;
           case 'ArrowLeft':
+          case 'j':
             this.skipBackward();
             break;
           case 'f':
@@ -397,11 +419,23 @@ export default Vue.extend({
             }
 
             break;
+          case 'm':
+            this.toggleMute();
+            break;
+        }
+      } else if (this.isMinimized && this.isPlaying) {
+        switch (e.key) {
+          case 'f':
+            if (this.getCurrentlyPlayingMediaType === 'Video') {
+              this.toggleMinimized();
+            }
+
+            break;
         }
       }
     },
-    handleVideoClick(e: MouseEvent) {
-      const target = e.target as any;
+    handleVideoClick(e: any) {
+      const target = e.target;
 
       if (
         target?.classList?.contains('player-overlay') &&

--- a/src/components/Players/PlayerManager.vue
+++ b/src/components/Players/PlayerManager.vue
@@ -391,6 +391,12 @@ export default Vue.extend({
           case 'ArrowLeft':
             this.skipBackward();
             break;
+          case 'f':
+            if (this.getCurrentlyPlayingMediaType === 'Video') {
+              this.toggleFullScreen();
+            }
+
+            break;
         }
       }
     },


### PR DESCRIPTION
I don't know if I'm the only one
but I find it really **_vital for a good user experience_** to have a quick control on the player (especially for videos).

I think the following features are very very important:
- SPACE for Play / Pause
- Click to Play / Pause (only on the video and not on the rest of the UI)
and less important but still very comfortable
- press 'f' for the fullscreen toggle

We only think about when the doorbell rings and we have to quickly pause.

It can be frustrating to have to grab the mouse and correctly aim for the play / pause icon when time is running out.

Press the video or press space, are immediate solutions, applicable even (and above all) when you are in a hurry.

---------------------------

I noticed that a handleKeyPress was already provided, but the listener was instantiated only when the mutation TOGGLE_MINIMIZE = false is performed (and therefore not at the first opening of the player)

Since I did not want to open a PR before discussing it, I have prepared a [PR on my fork](https://github.com/doc-code-hub/jellyfin-vue/pull/3/files), just to show you the changes I propose (**which I have tested without encountering any issues**) in a clear and immediate way.

The changes I made are (regarding the Click and 'f' press) referring only to the MediaType = 'Video'.

I also changed the listener from 'keydown' to 'keyup' to **avoid** the **toggle loop** when holding a key